### PR TITLE
fix: remove DEV_TOOL and document file auto-discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,12 +154,7 @@ Each entry in `Flows/` is a Postman request with:
 ```javascript
 // Org admin logs in, creates an organisation, edits it, and views it.
 // Run: newman-flows run "Org admin creates org"
-steps([
-  "Org admin login",
-  "Create Organization",
-  "Edit Organization",
-  "View Organization",
-]);
+steps(['Org admin login', 'Create Organization', 'Edit Organization', 'View Organization']);
 ```
 
 Step names must **exactly match** request names in `Requests/`.
@@ -213,24 +208,18 @@ npx newman-flows run --all --collection ./path/to/my.postman_collection.json
 Resolution order:
 
 1. `--env <path>` flag (absolute or relative to cwd)
-2. `DEV_TOOL` env var selects which file to prefer:
-   - Any value containing `docker` (e.g. `docker`, `docker-compose`) → first file whose name contains `docker` (case-insensitive)
-   - Anything else (or unset) → first file whose name contains `ddev` (case-insensitive)
-3. First `*.postman_environment.json` in `<cwd>/dev/Postman/` (alphabetical fallback)
-4. No environment file — Newman runs without one
+2. First `*.postman_environment.json` in `<cwd>/dev/Postman/` (alphabetical)
+3. No environment file — Newman runs without one
 
 ```bash
-# Default: picks a file containing "ddev" in its name
+# Auto-discovered (alphabetically first env file in dev/Postman/)
 npx newman-flows run --all
 
-# Docker / docker-compose environment
-DEV_TOOL=docker-compose npx newman-flows run --all
-
-# Explicit path — bypasses all auto-discovery
+# Explicit path — use this when you have multiple env files
 npx newman-flows run --all --env ./dev/Postman/staging.postman_environment.json
 ```
 
-The keyword matching is intentionally loose so names like `"Drupal Ddev …"` and `"Drupal Docker …"` are found without needing an exact prefix.
+When your project has multiple environment files (local, staging, CI, etc.), pass `--env` explicitly rather than relying on auto-discovery.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -188,13 +188,49 @@ Export the collection from Postman desktop (`File → Export → Collection v2.1
 
 ---
 
-## Collection path
+## File discovery
 
-By default `newman-flows` looks for a `*.postman_collection.json` file in `<cwd>/dev/Postman/`. Override with a flag:
+`newman-flows` resolves the collection and environment from `process.cwd()` — the directory you run the command from. When used via `npm run`, that is always the project root.
+
+### Collection
+
+Resolution order:
+
+1. `--collection <path>` flag (absolute or relative to cwd)
+2. First `*.postman_collection.json` found in `<cwd>/dev/Postman/` (alphabetical — deterministic when multiple files exist)
+3. Error with a helpful message
 
 ```bash
+# Auto-discovered from dev/Postman/
+npx newman-flows run --all
+
+# Explicit override
 npx newman-flows run --all --collection ./path/to/my.postman_collection.json
 ```
+
+### Environment
+
+Resolution order:
+
+1. `--env <path>` flag (absolute or relative to cwd)
+2. `DEV_TOOL` env var selects which file to prefer:
+   - Any value containing `docker` (e.g. `docker`, `docker-compose`) → first file whose name contains `docker` (case-insensitive)
+   - Anything else (or unset) → first file whose name contains `ddev` (case-insensitive)
+3. First `*.postman_environment.json` in `<cwd>/dev/Postman/` (alphabetical fallback)
+4. No environment file — Newman runs without one
+
+```bash
+# Default: picks a file containing "ddev" in its name
+npx newman-flows run --all
+
+# Docker / docker-compose environment
+DEV_TOOL=docker-compose npx newman-flows run --all
+
+# Explicit path — bypasses all auto-discovery
+npx newman-flows run --all --env ./dev/Postman/staging.postman_environment.json
+```
+
+The keyword matching is intentionally loose so names like `"Drupal Ddev …"` and `"Drupal Docker …"` are found without needing an exact prefix.
 
 ---
 

--- a/src/lib/collection.ts
+++ b/src/lib/collection.ts
@@ -81,7 +81,10 @@ export function resolveCollectionPath(override?: string): string {
 
   const dir = path.join(process.cwd(), POSTMAN_DIR);
   if (fs.existsSync(dir)) {
-    const match = fs.readdirSync(dir).sort().find((f) => f.endsWith('.postman_collection.json'));
+    const match = fs
+      .readdirSync(dir)
+      .sort()
+      .find((f) => f.endsWith('.postman_collection.json'));
     if (match) return path.join(dir, match);
   }
 
@@ -95,13 +98,11 @@ export function resolveCollectionPath(override?: string): string {
  *
  * Resolution order:
  *   1. Explicit override (--env flag or programmatic option)
- *   2. DEV_TOOL env var: any value containing "docker" (e.g. "docker",
- *      "docker-compose") → first environment file whose name contains "docker"
- *      (case-insensitive); otherwise first file whose name contains "ddev".
- *      This matches common naming conventions like "Drupal Ddev …" or just
- *      "Ddev …".
- *   3. First *.postman_environment.json in <cwd>/dev/Postman/ (alphabetical)
- *   4. undefined (Newman runs without an environment file)
+ *   2. First *.postman_environment.json in <cwd>/dev/Postman/ (alphabetical)
+ *   3. undefined (Newman runs without an environment file)
+ *
+ * When multiple environment files exist (e.g. one per environment), pass
+ * --env <path> to select the one you want.
  */
 export function resolveEnvironmentPath(override?: string): string | undefined {
   if (override) return path.isAbsolute(override) ? override : path.resolve(process.cwd(), override);
@@ -109,11 +110,11 @@ export function resolveEnvironmentPath(override?: string): string | undefined {
   const dir = path.join(process.cwd(), POSTMAN_DIR);
   if (!fs.existsSync(dir)) return undefined;
 
-  const files = fs.readdirSync(dir).sort().filter((f) => f.endsWith('.postman_environment.json'));
+  const files = fs
+    .readdirSync(dir)
+    .sort()
+    .filter((f) => f.endsWith('.postman_environment.json'));
   if (files.length === 0) return undefined;
 
-  const devTool = (process.env['DEV_TOOL'] ?? 'ddev').toLowerCase();
-  const keyword = devTool.includes('docker') ? 'docker' : 'ddev';
-  const preferred = files.find((f) => f.toLowerCase().includes(keyword));
-  return path.join(dir, preferred ?? files[0]);
+  return path.join(dir, files[0]);
 }

--- a/test/unit/collection.test.ts
+++ b/test/unit/collection.test.ts
@@ -225,55 +225,15 @@ describe('resolveEnvironmentPath', () => {
   it('auto-discovers the first *.postman_environment.json', () => {
     const dir = path.join(tmpDir, 'dev', 'Postman');
     fs.mkdirSync(dir, { recursive: true });
-    fs.writeFileSync(path.join(dir, 'Ddev.postman_environment.json'), '{}');
-    expect(resolveEnvironmentPath()).toContain('.postman_environment.json');
+    fs.writeFileSync(path.join(dir, 'my-env.postman_environment.json'), '{}');
+    expect(resolveEnvironmentPath()).toContain('my-env.postman_environment.json');
   });
 
-  it('prefers the Ddev env when DEV_TOOL is not set', () => {
+  it('returns the alphabetically first file when multiple exist', () => {
     const dir = path.join(tmpDir, 'dev', 'Postman');
     fs.mkdirSync(dir, { recursive: true });
-    fs.writeFileSync(path.join(dir, 'Docker.postman_environment.json'), '{}');
-    fs.writeFileSync(path.join(dir, 'Ddev.postman_environment.json'), '{}');
-    delete process.env['DEV_TOOL'];
-    expect(resolveEnvironmentPath()).toContain('Ddev');
-  });
-
-  it('prefers the Docker env when DEV_TOOL=docker', () => {
-    const dir = path.join(tmpDir, 'dev', 'Postman');
-    fs.mkdirSync(dir, { recursive: true });
-    fs.writeFileSync(path.join(dir, 'Docker.postman_environment.json'), '{}');
-    fs.writeFileSync(path.join(dir, 'Ddev.postman_environment.json'), '{}');
-    process.env['DEV_TOOL'] = 'docker';
-    expect(resolveEnvironmentPath()).toContain('Docker');
-    delete process.env['DEV_TOOL'];
-  });
-
-  it('prefers the Docker env when DEV_TOOL=docker-compose (substring match)', () => {
-    const dir = path.join(tmpDir, 'dev', 'Postman');
-    fs.mkdirSync(dir, { recursive: true });
-    fs.writeFileSync(path.join(dir, 'Docker.postman_environment.json'), '{}');
-    fs.writeFileSync(path.join(dir, 'Ddev.postman_environment.json'), '{}');
-    process.env['DEV_TOOL'] = 'docker-compose';
-    expect(resolveEnvironmentPath()).toContain('Docker');
-    delete process.env['DEV_TOOL'];
-  });
-
-  it('matches "Drupal Ddev" env filename (real-world prefix naming)', () => {
-    const dir = path.join(tmpDir, 'dev', 'Postman');
-    fs.mkdirSync(dir, { recursive: true });
-    fs.writeFileSync(path.join(dir, 'Drupal Docker.postman_environment.json'), '{}');
-    fs.writeFileSync(path.join(dir, 'Drupal Ddev.postman_environment.json'), '{}');
-    delete process.env['DEV_TOOL'];
-    expect(resolveEnvironmentPath()).toContain('Drupal Ddev');
-  });
-
-  it('matches "Drupal Docker" env filename when DEV_TOOL=docker-compose', () => {
-    const dir = path.join(tmpDir, 'dev', 'Postman');
-    fs.mkdirSync(dir, { recursive: true });
-    fs.writeFileSync(path.join(dir, 'Drupal Docker.postman_environment.json'), '{}');
-    fs.writeFileSync(path.join(dir, 'Drupal Ddev.postman_environment.json'), '{}');
-    process.env['DEV_TOOL'] = 'docker-compose';
-    expect(resolveEnvironmentPath()).toContain('Drupal Docker');
-    delete process.env['DEV_TOOL'];
+    fs.writeFileSync(path.join(dir, 'staging.postman_environment.json'), '{}');
+    fs.writeFileSync(path.join(dir, 'local.postman_environment.json'), '{}');
+    expect(resolveEnvironmentPath()).toContain('local.postman_environment.json');
   });
 });


### PR DESCRIPTION
## What changed

### Remove `DEV_TOOL` from environment discovery

`resolveEnvironmentPath()` was reading a `DEV_TOOL` environment variable to prefer a "ddev" or "docker" environment file. That variable is a convention belonging to consumer projects — it has no place in a generic public package.

**Before:**
```
DEV_TOOL=docker → picks first file whose name contains "docker"
DEV_TOOL unset  → picks first file whose name contains "ddev"
```

**After:**
```
Always picks the alphabetically first *.postman_environment.json.
Pass --env <path> to select a specific file.
```

4 `DEV_TOOL`-specific unit tests removed and replaced with 2 generic ones.

### Document file auto-discovery

The README had no explanation of how `newman-flows` finds the collection and environment without `--collection` / `--env` flags. Added a **File discovery** section covering:

- `process.cwd()` as the anchor (always the project root under `npm run`)
- Collection resolution order: flag → first `*.postman_collection.json` in `dev/Postman/` → error
- Environment resolution order: flag → first `*.postman_environment.json` in `dev/Postman/` → none
- Guidance to use `--env` explicitly when multiple environment files exist

## Test plan

- [ ] `npm run test:unit` — 88 tests pass
- [ ] Confirm `DEV_TOOL` does not appear in `src/`, `test/`, or `README.md`