### PR TITLE
refactor: proxy Newman reporter options instead of managing resultsDir

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,10 +68,13 @@ npx newman-flows run --all \
   --collection ./dev/Postman/my-api.postman_collection.json
 ```
 
-### Write reports to a custom directory
+### Save reports
 
 ```bash
-npx newman-flows run --all --results-dir ./ci-reports
+npx newman-flows run --all \
+  --reporters cli,junit,htmlextra \
+  --reporter-junit-export ./test/results/newman/results.xml \
+  --reporter-htmlextra-export ./test/results/newman/report.html
 ```
 
 ### List flows
@@ -225,16 +228,50 @@ When your project has multiple environment files (local, staging, CI, etc.), pas
 
 ## Reports
 
-JUnit XML and HTML reports are written to `test/results/newman/` by default. Override with `--results-dir`:
+`newman-flows` does not manage reporters — it passes your reporter configuration straight to Newman. By default only the `cli` reporter runs and nothing is written to disk.
+
+To save reports, pass the same reporter flags you would use with Newman directly:
 
 ```bash
-npx newman-flows run --all --results-dir ./ci-reports
+# JUnit XML only
+npx newman-flows run --all \
+  --reporters cli,junit \
+  --reporter-junit-export ./test/results/newman/results.xml
+
+# JUnit XML + HTML report
+npx newman-flows run --all \
+  --reporters cli,junit,htmlextra \
+  --reporter-junit-export ./test/results/newman/results.xml \
+  --reporter-htmlextra-export ./test/results/newman/report.html
+
+# JSON report
+npx newman-flows run --all \
+  --reporters cli,json \
+  --reporter-json-export ./test/results/newman/results.json
 ```
 
-| File          | Format                     |
-| ------------- | -------------------------- |
-| `results.xml` | JUnit XML (consumed by CI) |
-| `report.html` | Human-readable HTML report |
+The output directory must exist before running, or you can create it in the same command:
+
+```bash
+mkdir -p test/results/newman && npx newman-flows run --all \
+  --reporters cli,junit \
+  --reporter-junit-export ./test/results/newman/results.xml
+```
+
+### Programmatic API
+
+Pass `reporters` and `reporter` directly — they map 1-to-1 to Newman's own options:
+
+```typescript
+await runAllFlows({
+  collection: './dev/Postman/my-api.postman_collection.json',
+  reporters: ['cli', 'junit', 'htmlextra'],
+  reporter: {
+    junit:     { export: './test/results/newman/results.xml' },
+    htmlextra: { export: './test/results/newman/report.html' },
+  },
+});
+```
 
 ---
 
@@ -242,7 +279,11 @@ npx newman-flows run --all --results-dir ./ci-reports
 
 ```yaml
 - name: Run all flows
-  run: npx newman-flows run --all --results-dir ./test/results/newman
+  run: |
+    mkdir -p test/results/newman
+    npx newman-flows run --all \
+      --reporters cli,junit \
+      --reporter-junit-export ./test/results/newman/results.xml
 
 - name: Upload flow reports
   if: always()

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -57,7 +57,10 @@ program
   .option('--all', 'run every flow defined in the Flows/ folder')
   .option('--collection <path>', 'path to the Postman collection JSON file')
   .option('--env <path>', 'path to a Postman environment JSON file')
-  .option('--results-dir <path>', 'directory for junit XML and HTML reports')
+  .option('--reporters <list>', 'comma-separated list of Newman reporters (default: cli)')
+  .option('--reporter-junit-export <path>', 'export path for the JUnit XML report')
+  .option('--reporter-htmlextra-export <path>', 'export path for the HTML report')
+  .option('--reporter-json-export <path>', 'export path for the JSON report')
   .action(
     async (
       flowName: string | undefined,
@@ -65,22 +68,34 @@ program
         all?: boolean;
         collection?: string;
         env?: string;
-        resultsDir?: string;
+        reporters?: string;
+        reporterJunitExport?: string;
+        reporterHtmlextraExport?: string;
+        reporterJsonExport?: string;
       },
     ) => {
       try {
+        const reporters = opts.reporters ? opts.reporters.split(',').map((r) => r.trim()) : undefined;
+
+        const reporter: Record<string, unknown> = {};
+        if (opts.reporterJunitExport) reporter['junit'] = { export: opts.reporterJunitExport };
+        if (opts.reporterHtmlextraExport) reporter['htmlextra'] = { export: opts.reporterHtmlextraExport };
+        if (opts.reporterJsonExport) reporter['json'] = { export: opts.reporterJsonExport };
+
         if (opts.all) {
           await runAllFlows({
             collection: resolveCollectionPath(opts.collection),
             env: opts.env,
-            resultsDir: opts.resultsDir,
+            reporters,
+            reporter: Object.keys(reporter).length ? reporter : undefined,
           });
         } else if (flowName) {
           await runFlow({
             collection: resolveCollectionPath(opts.collection),
             flow: flowName,
             env: opts.env,
-            resultsDir: opts.resultsDir,
+            reporters,
+            reporter: Object.keys(reporter).length ? reporter : undefined,
           });
         } else {
           console.error('Provide a flow name or --all.\n');

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -6,10 +6,11 @@
  * It contains only the requests belonging to the flow, in the declared order,
  * and strips any collection-level scripts that reference `_flow_steps` (a
  * routing helper that is unnecessary when running a flat sequence).
+ *
+ * Reporter configuration is passed straight through to newman.run() — this
+ * package does not add or default any reporters beyond Newman's own defaults.
  */
 
-import * as fs from 'fs';
-import * as path from 'path';
 import newman, { type NewmanRunOptions } from 'newman';
 import { findRequest, loadCollection, resolveCollectionPath, resolveEnvironmentPath } from '../lib/collection.js';
 import { extractFlowDef, findFlowRequest, listFlows } from '../lib/flows.js';
@@ -59,34 +60,22 @@ async function runFlowDef(
   collection: PostmanCollection,
   flowDef: FlowDef,
   envPath: string | undefined,
-  resultsDir: string | undefined,
+  reporters: string | string[] | undefined,
+  reporter: Record<string, unknown> | undefined,
 ): Promise<void> {
   return new Promise((resolve, reject) => {
     const tempCollection = buildTempCollection(collection, flowDef);
 
-    if (resultsDir) {
-      fs.mkdirSync(resultsDir, { recursive: true });
-    }
-
     console.log(`\n▶ Running flow: ${flowDef.name}`);
     console.log(`  Steps: ${flowDef.steps.join(' → ')}\n`);
-
-    const reporters: string[] = ['cli'];
-    const reporter: Record<string, unknown> = {};
-
-    if (resultsDir) {
-      reporters.push('junit', 'htmlextra');
-      reporter['junit'] = { export: path.join(resultsDir, 'results.xml') };
-      reporter['htmlextra'] = { export: path.join(resultsDir, 'report.html') };
-    }
 
     newman.run(
       {
         collection: tempCollection as NewmanRunOptions['collection'],
         environment: envPath,
         insecure: true,
-        reporters,
-        reporter,
+        reporters: reporters ?? 'cli',
+        reporter: reporter ?? {},
       },
       (err, summary) => {
         if (err) return reject(err);
@@ -114,8 +103,10 @@ async function runFlowDef(
  * @param opts.flow      - Exact name of the flow to run (case-sensitive).
  * @param opts.env       - Path to a `.postman_environment.json` file, or
  *   `undefined` to auto-discover / run without an environment.
- * @param opts.resultsDir - Directory for JUnit XML and HTML reports. Defaults
- *   to `<cwd>/test/results/newman`. Created automatically if absent.
+ * @param opts.reporters - Newman reporters to activate (e.g. `['cli', 'junit']`).
+ *   Defaults to `'cli'`.
+ * @param opts.reporter  - Per-reporter options passed directly to `newman.run()`
+ *   (e.g. `{ junit: { export: './results.xml' } }`).
  *
  * @throws {Error} If the collection or environment file cannot be resolved.
  * @throws {Error} If the named flow does not exist in the collection.
@@ -124,15 +115,10 @@ async function runFlowDef(
 export async function runFlow(opts: RunOptions & { flow: string }): Promise<void> {
   const collectionPath = resolveCollectionPath(opts.collection);
   const envPath = resolveEnvironmentPath(opts.env);
-  const resultsDir =
-    opts.resultsDir !== undefined
-      ? path.resolve(process.cwd(), opts.resultsDir)
-      : path.join(process.cwd(), 'test', 'results', 'newman');
-
   const collection = loadCollection(collectionPath);
   const flowReq = findFlowRequest(collection, opts.flow);
   const flowDef = extractFlowDef(flowReq);
-  await runFlowDef(collection, flowDef, envPath, resultsDir);
+  await runFlowDef(collection, flowDef, envPath, opts.reporters, opts.reporter);
 }
 
 /**
@@ -142,8 +128,10 @@ export async function runFlow(opts: RunOptions & { flow: string }): Promise<void
  *   `undefined` to auto-discover from `<cwd>/dev/Postman/`.
  * @param opts.env       - Path to a `.postman_environment.json` file, or
  *   `undefined` to auto-discover / run without an environment.
- * @param opts.resultsDir - Directory for JUnit XML and HTML reports. Defaults
- *   to `<cwd>/test/results/newman`. Created automatically if absent.
+ * @param opts.reporters - Newman reporters to activate (e.g. `['cli', 'junit']`).
+ *   Defaults to `'cli'`.
+ * @param opts.reporter  - Per-reporter options passed directly to `newman.run()`
+ *   (e.g. `{ junit: { export: './results.xml' } }`).
  *
  * @throws {Error} If the collection or environment file cannot be resolved.
  * @throws {Error} If the collection contains no flows.
@@ -152,11 +140,6 @@ export async function runFlow(opts: RunOptions & { flow: string }): Promise<void
 export async function runAllFlows(opts: RunOptions): Promise<void> {
   const collectionPath = resolveCollectionPath(opts.collection);
   const envPath = resolveEnvironmentPath(opts.env);
-  const resultsDir =
-    opts.resultsDir !== undefined
-      ? path.resolve(process.cwd(), opts.resultsDir)
-      : path.join(process.cwd(), 'test', 'results', 'newman');
-
   const collection = loadCollection(collectionPath);
   const flowRequests = listFlows(collection);
 
@@ -166,7 +149,7 @@ export async function runAllFlows(opts: RunOptions): Promise<void> {
 
   for (const flowReq of flowRequests) {
     const flowDef = extractFlowDef(flowReq);
-    await runFlowDef(collection, flowDef, envPath, resultsDir);
+    await runFlowDef(collection, flowDef, envPath, opts.reporters, opts.reporter);
   }
 
   console.log('\n✅ All flows passed.');

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -75,6 +75,18 @@ export interface RunOptions {
   collection: string;
   /** Absolute or relative path to a Postman environment JSON file. */
   env?: string;
-  /** Directory for JUnit XML and HTML reports. Defaults to `<cwd>/test/results/newman`. */
-  resultsDir?: string;
+  /**
+   * Newman reporters to activate. Accepts a single reporter name or an array.
+   * Defaults to `'cli'` when omitted.
+   *
+   * @example ['cli', 'junit', 'htmlextra']
+   */
+  reporters?: string | string[];
+  /**
+   * Per-reporter configuration passed directly to `newman.run()`.
+   * Keys are reporter names; values are the reporter-specific option objects.
+   *
+   * @example { junit: { export: './results.xml' }, htmlextra: { export: './report.html' } }
+   */
+  reporter?: Record<string, unknown>;
 }

--- a/test/integration/run-flow.test.ts
+++ b/test/integration/run-flow.test.ts
@@ -61,7 +61,6 @@ describe('runFlow', () => {
         collection: COLLECTION_PATH,
         flow: 'Organisation creation',
         env: envPath,
-        resultsDir: path.join(tmpDir, 'results-org'),
       }),
     ).resolves.toBeUndefined();
   }, 30_000);
@@ -73,7 +72,6 @@ describe('runFlow', () => {
         collection: COLLECTION_PATH,
         flow: 'Member invitation',
         env: envPath,
-        resultsDir: path.join(tmpDir, 'results-inv'),
       }),
     ).resolves.toBeUndefined();
   }, 30_000);
@@ -101,7 +99,6 @@ describe('runAllFlows', () => {
       runAllFlows({
         collection: COLLECTION_PATH,
         env: envPath,
-        resultsDir: path.join(tmpDir, 'results-all'),
       }),
     ).resolves.toBeUndefined();
   }, 60_000);


### PR DESCRIPTION
## Summary

- Removes the `resultsDir` abstraction from `RunOptions` — the package no longer manages directories or hard-codes any reporters beyond `cli`
- Adds `reporters` and `reporter` to `RunOptions`, passed straight through to `newman.run()` — the same fields Newman itself accepts
- CLI gains `--reporters`, `--reporter-junit-export`, `--reporter-htmlextra-export`, `--reporter-json-export` to mirror Newman's own CLI interface
- Updates README with CLI examples, programmatic API example, and updated CI snippet

## Why

`newman-flows` is for running flows, not managing reports. Newman already has a complete, well-documented reporter system. Wrapping it in a custom `resultsDir` abstraction added complexity, leaked implementation choices, and forced users to learn a different interface. Proxying Newman's own options directly means users can use any Newman reporter without `newman-flows` needing to know about it.

## Changes

| File | Change |
|------|--------|
| `src/lib/types.ts` | Replace `resultsDir?: string` with `reporters?: string \| string[]` and `reporter?: Record<string, unknown>` |
| `src/commands/run.ts` | Remove `fs`/`path` imports, directory creation, and hard-coded reporter wiring; pass `reporters`/`reporter` through to `newman.run()` |
| `src/cli.ts` | Replace `--results-dir` with `--reporters`, `--reporter-junit-export`, `--reporter-htmlextra-export`, `--reporter-json-export` |
| `test/integration/run-flow.test.ts` | Remove `resultsDir` — integration tests use the default `cli` reporter only |
| `README.md` | Updated Reports section and CI example |

## Test plan

- [ ] `npm run lint` passes
- [ ] `npm run typecheck` passes
- [ ] `npm run test:unit` passes (88 tests)
- [ ] `npm run test:integration` passes end-to-end