### PR TITLE
feat: warn when multiple collection or environment files are auto-discovered

### DIFF
--- a/src/lib/collection.ts
+++ b/src/lib/collection.ts
@@ -81,11 +81,18 @@ export function resolveCollectionPath(override?: string): string {
 
   const dir = path.join(process.cwd(), POSTMAN_DIR);
   if (fs.existsSync(dir)) {
-    const match = fs
+    const matches = fs
       .readdirSync(dir)
       .sort()
-      .find((f) => f.endsWith('.postman_collection.json'));
-    if (match) return path.join(dir, match);
+      .filter((f) => f.endsWith('.postman_collection.json'));
+    if (matches.length > 1) {
+      console.warn(
+        `Warning: multiple collection files found in ${POSTMAN_DIR}/:\n` +
+          matches.map((f) => `  ${f}`).join('\n') +
+          `\nUsing "${matches[0]}". Pass --collection <path> to select a different one.`,
+      );
+    }
+    if (matches.length > 0) return path.join(dir, matches[0]);
   }
 
   throw new Error(
@@ -115,6 +122,14 @@ export function resolveEnvironmentPath(override?: string): string | undefined {
     .sort()
     .filter((f) => f.endsWith('.postman_environment.json'));
   if (files.length === 0) return undefined;
+
+  if (files.length > 1) {
+    console.warn(
+      `Warning: multiple environment files found in ${POSTMAN_DIR}/:\n` +
+        files.map((f) => `  ${f}`).join('\n') +
+        `\nUsing "${files[0]}". Pass --env <path> to select a different one.`,
+    );
+  }
 
   return path.join(dir, files[0]);
 }

--- a/test/unit/collection.test.ts
+++ b/test/unit/collection.test.ts
@@ -9,7 +9,7 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   findFolder,
   findRequest,
@@ -29,18 +29,14 @@ const items: PostmanItem[] = [
     item: [
       {
         name: 'Authentication',
-        item: [
-          { name: 'Login', request: { method: 'POST', url: { raw: 'http://x/login' } } },
-        ],
+        item: [{ name: 'Login', request: { method: 'POST', url: { raw: 'http://x/login' } } }],
       },
       { name: 'Get User', request: { method: 'GET', url: { raw: 'http://x/user' } } },
     ],
   },
   {
     name: 'Flows',
-    item: [
-      { name: 'Onboarding', request: { method: 'FLOW', url: { raw: 'about:blank' } } },
-    ],
+    item: [{ name: 'Onboarding', request: { method: 'FLOW', url: { raw: 'about:blank' } } }],
   },
 ];
 
@@ -172,7 +168,7 @@ describe('resolveCollectionPath', () => {
 
   it('resolves a relative override against cwd', () => {
     const result = resolveCollectionPath('relative/col.json');
-expect(result).toBe(path.join(tmpDir, 'relative/col.json'));
+    expect(result).toBe(path.join(tmpDir, 'relative/col.json'));
   });
 
   it('auto-discovers a *.postman_collection.json in dev/Postman/', () => {
@@ -182,12 +178,18 @@ expect(result).toBe(path.join(tmpDir, 'relative/col.json'));
     expect(resolveCollectionPath()).toContain('My API.postman_collection.json');
   });
 
-  it('returns the alphabetically first collection when multiple exist', () => {
+  it('returns the alphabetically first collection when multiple exist and warns', () => {
     const dir = path.join(tmpDir, 'dev', 'Postman');
     fs.mkdirSync(dir, { recursive: true });
     fs.writeFileSync(path.join(dir, 'beta.postman_collection.json'), '{}');
     fs.writeFileSync(path.join(dir, 'alpha.postman_collection.json'), '{}');
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     expect(resolveCollectionPath()).toContain('alpha.postman_collection.json');
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn.mock.calls[0][0]).toContain('multiple collection files found');
+    expect(warn.mock.calls[0][0]).toContain('alpha.postman_collection.json');
+    expect(warn.mock.calls[0][0]).toContain('--collection');
+    warn.mockRestore();
   });
 
   it('throws when no collection can be found', () => {
@@ -229,11 +231,17 @@ describe('resolveEnvironmentPath', () => {
     expect(resolveEnvironmentPath()).toContain('my-env.postman_environment.json');
   });
 
-  it('returns the alphabetically first file when multiple exist', () => {
+  it('returns the alphabetically first file when multiple exist and warns', () => {
     const dir = path.join(tmpDir, 'dev', 'Postman');
     fs.mkdirSync(dir, { recursive: true });
     fs.writeFileSync(path.join(dir, 'staging.postman_environment.json'), '{}');
     fs.writeFileSync(path.join(dir, 'local.postman_environment.json'), '{}');
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     expect(resolveEnvironmentPath()).toContain('local.postman_environment.json');
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn.mock.calls[0][0]).toContain('multiple environment files found');
+    expect(warn.mock.calls[0][0]).toContain('local.postman_environment.json');
+    expect(warn.mock.calls[0][0]).toContain('--env');
+    warn.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary

- When auto-discovery finds more than one `*.postman_collection.json` in `dev/Postman/`, emits a `console.warn` listing all candidates, stating which one was selected (first alphabetically), and pointing to `--collection` to override
- Same behaviour for `*.postman_environment.json` → points to `--env`
- Updated unit tests to assert the warning is emitted with the correct content

## Test plan

- [ ] Single file present → no warning, existing behaviour unchanged
- [ ] Multiple collection files → warning lists all files, names the selected one, mentions `--collection`
- [ ] Multiple environment files → warning lists all files, names the selected one, mentions `--env`
- [ ] `npm run test:unit` passes (88 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)