### PR TITLE
chore: add pre-push git hook with format, lint, typecheck, and unit test checks

### DIFF
--- a/.github/hooks/pre-push
+++ b/.github/hooks/pre-push
@@ -1,0 +1,62 @@
+#!/bin/sh
+
+# Source bash profile to ensure nvm is loaded
+if [ "$(which npm)" == "" ]; then
+  if [ -f ~/.bash_profile ]; then
+    source ~/.bash_profile
+  elif [ -f ~/.bashrc ]; then
+    source ~/.bashrc
+  elif [ -f ~/.zshrc ]; then
+    source ~/.zshrc
+  fi
+fi
+
+# Check if docker is installed
+if [ "$(which docker)" == "" ]; then
+ # Append /usr/local/bin to PATH
+ export PATH=$PATH:/usr/local/bin
+fi
+
+run_check() {
+  LABEL=$1
+  CMD=$2
+  shift
+  printf "  %-30s" "$LABEL..."
+  OUTPUT=$($CMD 2>&1)
+  RESULT=$?
+  if [ $RESULT -ne 0 ]; then
+    echo "❌"
+    echo "$OUTPUT"
+    echo "Push aborted."
+    exit 1
+  fi
+  echo "✅"
+}
+
+run_check_warn() {
+  LABEL=$1
+  CMD=$2
+  FIX_CMD=$3
+  shift 3
+  printf "  %-30s" "$LABEL..."
+  OUTPUT=$($CMD 2>&1)
+  RESULT=$?
+  if [ $RESULT -ne 0 ]; then
+    echo "⚠️"
+    echo "$OUTPUT"
+    printf "  Run \`%s\` to fix automatically. Abort push? [Y/n] " "$FIX_CMD"
+    read -r REPLY </dev/tty
+    case "$REPLY" in
+      [nN]) echo "  Skipping $LABEL fix, continuing..." ;;
+      *) echo "Push aborted. Run \`$FIX_CMD\` then push again."; exit 1 ;;
+    esac
+  else
+    echo "✅"
+  fi
+}
+
+echo "Running pre-push checks..."
+run_check_warn "Prettier"   "npm run format -- --check" "npm run format"
+run_check_warn "ESLint"     "npm run lint"              "npm run lint:fix"
+run_check      "Typecheck"  "npm run typecheck"
+run_check      "Unit tests" "npm run test:unit"

--- a/.github/scripts/setup_hooks.sh
+++ b/.github/scripts/setup_hooks.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+echo "Setting up Git hooks..."
+
+HOOK_SRC_DIR=".github/hooks"
+GIT_HOOK_DIR=".git/hooks"
+
+# Skip silently when not in a Git repository (e.g. deploy artifact builds).
+if [ ! -d ".git" ]; then
+  exit 0
+fi
+
+# Copy hooks
+cp -a "$HOOK_SRC_DIR/." "$GIT_HOOK_DIR/"
+
+echo "Git hooks have been set up successfully in $GIT_HOOK_DIR"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -75,11 +75,14 @@ program
       },
     ) => {
       try {
-        const reporters = opts.reporters ? opts.reporters.split(',').map((r) => r.trim()) : undefined;
+        const reporters = opts.reporters
+          ? opts.reporters.split(',').map((r) => r.trim())
+          : undefined;
 
         const reporter: Record<string, unknown> = {};
         if (opts.reporterJunitExport) reporter['junit'] = { export: opts.reporterJunitExport };
-        if (opts.reporterHtmlextraExport) reporter['htmlextra'] = { export: opts.reporterHtmlextraExport };
+        if (opts.reporterHtmlextraExport)
+          reporter['htmlextra'] = { export: opts.reporterHtmlextraExport };
         if (opts.reporterJsonExport) reporter['json'] = { export: opts.reporterJsonExport };
 
         if (opts.all) {

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -12,7 +12,12 @@
  */
 
 import newman, { type NewmanRunOptions } from 'newman';
-import { findRequest, loadCollection, resolveCollectionPath, resolveEnvironmentPath } from '../lib/collection.js';
+import {
+  findRequest,
+  loadCollection,
+  resolveCollectionPath,
+  resolveEnvironmentPath,
+} from '../lib/collection.js';
 import { extractFlowDef, findFlowRequest, listFlows } from '../lib/flows.js';
 import type { FlowDef, PostmanCollection, RunOptions } from '../lib/types.js';
 
@@ -46,9 +51,7 @@ export function buildTempCollection(
     // "check _flow_steps is not set" doesn't cause a false-positive match.
     event: (collection.event ?? []).filter((e) => {
       const src = (e.script?.exec ?? []).join('\n');
-      const stripped = src
-        .replace(/"(?:[^"\\]|\\.)*"/g, '""')
-        .replace(/'(?:[^'\\]|\\.)*'/g, "''");
+      const stripped = src.replace(/"(?:[^"\\]|\\.)*"/g, '""').replace(/'(?:[^'\\]|\\.)*'/g, "''");
       return !/\b_flow_steps\b/.test(stripped);
     }),
     item: flowItems,

--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -188,7 +188,9 @@ export function printValidationResult(result: ValidationResult): boolean {
   }
   if (result.errors.length > 0) {
     result.errors.forEach((e) => console.error(`❌ ${e}`));
-    console.error(`\n${result.errors.length} error(s) found. Fix before importing or running flows.`);
+    console.error(
+      `\n${result.errors.length} error(s) found. Fix before importing or running flows.`,
+    );
     return false;
   }
   console.log('✅ Collection valid.');

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,13 @@
 export { getFlowSummaries, printFlowList } from './commands/list.js';
 export { runFlow, runAllFlows } from './commands/run.js';
 export { validateCollection, printValidationResult } from './commands/validate.js';
-export { loadCollection, resolveCollectionPath, resolveEnvironmentPath, findFolder, findRequest } from './lib/collection.js';
+export {
+  loadCollection,
+  resolveCollectionPath,
+  resolveEnvironmentPath,
+  findFolder,
+  findRequest,
+} from './lib/collection.js';
 export { listFlows, extractFlowDef, findFlowRequest } from './lib/flows.js';
 export type {
   FlowDef,

--- a/src/lib/flows.ts
+++ b/src/lib/flows.ts
@@ -43,9 +43,7 @@ const VM_TIMEOUT_MS = 1000;
 
 /** Replace quoted string literals with empty placeholders to avoid false-positive pattern matches on step names. */
 function stripStringLiterals(src: string): string {
-  return src
-    .replace(/"(?:[^"\\]|\\.)*"/g, '""')
-    .replace(/'(?:[^'\\]|\\.)*'/g, "''");
+  return src.replace(/"(?:[^"\\]|\\.)*"/g, '""').replace(/'(?:[^'\\]|\\.)*'/g, "''");
 }
 
 /** Throw if the script source references a forbidden identifier outside a string literal. */
@@ -55,7 +53,7 @@ function assertSafeSrc(flowName: string, src: string): void {
     if (pattern.test(stripped)) {
       throw new Error(
         `Pre-request script in "${flowName}" references a forbidden identifier ` +
-        `(matched: ${pattern.source}). Only steps([...]) calls are permitted in flow scripts.`,
+          `(matched: ${pattern.source}). Only steps([...]) calls are permitted in flow scripts.`,
       );
     }
   }

--- a/test/integration/mock-server.test.ts
+++ b/test/integration/mock-server.test.ts
@@ -57,7 +57,10 @@ describe('health', () => {
 
 describe('POST /api/auth/login', () => {
   it('returns an access_token', async () => {
-    const res = await post('/api/auth/login', { username: 'admin@example.com', password: 'secret' });
+    const res = await post('/api/auth/login', {
+      username: 'admin@example.com',
+      password: 'secret',
+    });
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json).toHaveProperty('access_token');
@@ -85,7 +88,10 @@ describe('POST /api/auth/login', () => {
 
 describe('Organisation creation flow', () => {
   it('logs in → creates → edits → views', async () => {
-    const loginRes = await post('/api/auth/login', { username: 'admin@example.com', password: 'secret' });
+    const loginRes = await post('/api/auth/login', {
+      username: 'admin@example.com',
+      password: 'secret',
+    });
     const { access_token } = await loginRes.json();
 
     const createRes = await post('/api/organisations', { name: 'Acme Corp' }, access_token);
@@ -94,7 +100,11 @@ describe('Organisation creation flow', () => {
     expect(org).toHaveProperty('id');
     expect(org.name).toBe('Acme Corp');
 
-    const editRes = await patch(`/api/organisations/${org.id}`, { name: 'Acme Corp (updated)' }, access_token);
+    const editRes = await patch(
+      `/api/organisations/${org.id}`,
+      { name: 'Acme Corp (updated)' },
+      access_token,
+    );
     expect(editRes.status).toBe(200);
     const edited = await editRes.json();
     expect(edited.name).toBe('Acme Corp (updated)');
@@ -113,7 +123,10 @@ describe('Organisation creation flow', () => {
   });
 
   it('returns 404 for unknown org', async () => {
-    const loginRes = await post('/api/auth/login', { username: 'admin@example.com', password: 'secret' });
+    const loginRes = await post('/api/auth/login', {
+      username: 'admin@example.com',
+      password: 'secret',
+    });
     const { access_token } = await loginRes.json();
     const res = await get('/api/organisations/does-not-exist', access_token);
     expect(res.status).toBe(404);
@@ -133,9 +146,15 @@ describe('Member invitation flow', () => {
     const { access_token: adminToken } = await adminLogin.json();
     const { access_token: memberToken } = await memberLogin.json();
 
-    const org = await (await post('/api/organisations', { name: 'Invite Test Org' }, adminToken)).json();
+    const org = await (
+      await post('/api/organisations', { name: 'Invite Test Org' }, adminToken)
+    ).json();
 
-    const invRes = await post(`/api/organisations/${org.id}/invitations`, { email: 'member@example.com' }, adminToken);
+    const invRes = await post(
+      `/api/organisations/${org.id}/invitations`,
+      { email: 'member@example.com' },
+      adminToken,
+    );
     expect(invRes.status).toBe(201);
     const inv = await invRes.json();
     expect(inv).toHaveProperty('id');
@@ -148,15 +167,28 @@ describe('Member invitation flow', () => {
 
     const viewRes = await get(`/api/organisations/${org.id}`, adminToken);
     const final = await viewRes.json();
-    expect(final.members.some((m: { email: string }) => m.email === 'member@example.com')).toBe(true);
+    expect(final.members.some((m: { email: string }) => m.email === 'member@example.com')).toBe(
+      true,
+    );
   });
 
   it('returns 409 if invitation already accepted', async () => {
-    const loginRes = await post('/api/auth/login', { username: 'admin@example.com', password: 'secret' });
+    const loginRes = await post('/api/auth/login', {
+      username: 'admin@example.com',
+      password: 'secret',
+    });
     const { access_token } = await loginRes.json();
 
-    const org = await (await post('/api/organisations', { name: 'Double Accept Org' }, access_token)).json();
-    const inv = await (await post(`/api/organisations/${org.id}/invitations`, { email: 'x@example.com' }, access_token)).json();
+    const org = await (
+      await post('/api/organisations', { name: 'Double Accept Org' }, access_token)
+    ).json();
+    const inv = await (
+      await post(
+        `/api/organisations/${org.id}/invitations`,
+        { email: 'x@example.com' },
+        access_token,
+      )
+    ).json();
 
     await post(`/api/invitations/${inv.id}/accept`, {}, access_token);
     const res = await post(`/api/invitations/${inv.id}/accept`, {}, access_token);

--- a/test/unit/flows.test.ts
+++ b/test/unit/flows.test.ts
@@ -27,13 +27,16 @@ function makeFlowRequest(name: string, steps: string[], execLines?: string[]): P
   };
 }
 
-function makeCollection(flowItems: PostmanItem[], extraItems: PostmanItem[] = []): PostmanCollection {
+function makeCollection(
+  flowItems: PostmanItem[],
+  extraItems: PostmanItem[] = [],
+): PostmanCollection {
   return {
-    info: { name: 'Test', schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json' },
-    item: [
-      ...extraItems,
-      { name: 'Flows', item: flowItems },
-    ],
+    info: {
+      name: 'Test',
+      schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json',
+    },
+    item: [...extraItems, { name: 'Flows', item: flowItems }],
   };
 }
 
@@ -43,7 +46,10 @@ function makeCollection(flowItems: PostmanItem[], extraItems: PostmanItem[] = []
 
 describe('runSandboxed', () => {
   it('captures a valid steps() call', () => {
-    expect(runSandboxed('My Flow', "steps(['Login', 'Create Org']);")).toEqual(['Login', 'Create Org']);
+    expect(runSandboxed('My Flow', "steps(['Login', 'Create Org']);")).toEqual([
+      'Login',
+      'Create Org',
+    ]);
   });
 
   it('rejects scripts that reference "constructor"', () => {
@@ -53,27 +59,25 @@ describe('runSandboxed', () => {
   });
 
   it('rejects scripts that reference "process"', () => {
-    expect(() =>
-      runSandboxed('Attack', 'var p = process; steps(["a"]);'),
-    ).toThrow('forbidden identifier');
+    expect(() => runSandboxed('Attack', 'var p = process; steps(["a"]);')).toThrow(
+      'forbidden identifier',
+    );
   });
 
   it('rejects scripts that reference "require"', () => {
-    expect(() =>
-      runSandboxed('Attack', 'require("fs"); steps(["a"]);'),
-    ).toThrow('forbidden identifier');
+    expect(() => runSandboxed('Attack', 'require("fs"); steps(["a"]);')).toThrow(
+      'forbidden identifier',
+    );
   });
 
   it('rejects scripts that reference "eval"', () => {
-    expect(() =>
-      runSandboxed('Attack', 'eval("steps([\'a\'])");'),
-    ).toThrow('forbidden identifier');
+    expect(() => runSandboxed('Attack', 'eval("steps([\'a\'])");')).toThrow('forbidden identifier');
   });
 
   it('rejects scripts that reference "Function"', () => {
-    expect(() =>
-      runSandboxed('Attack', 'new Function("return process")();'),
-    ).toThrow('forbidden identifier');
+    expect(() => runSandboxed('Attack', 'new Function("return process")();')).toThrow(
+      'forbidden identifier',
+    );
   });
 
   it('allows step names that contain forbidden words as substrings inside strings', () => {
@@ -85,45 +89,35 @@ describe('runSandboxed', () => {
   });
 
   it('enforces a 1-second timeout on infinite loops', () => {
-    expect(() =>
-      runSandboxed('Hang', 'while(true){}'),
-    ).toThrow(); // script timed out or forbidden pattern match
+    expect(() => runSandboxed('Hang', 'while(true){}')).toThrow(); // script timed out or forbidden pattern match
   }, 3000);
 
   it('throws when steps() receives a non-array', () => {
-    expect(() =>
-      runSandboxed('Bad', 'steps("not an array");'),
-    ).toThrow('must be an array');
+    expect(() => runSandboxed('Bad', 'steps("not an array");')).toThrow('must be an array');
   });
 
   it('throws when steps() receives an array with non-string elements', () => {
-    expect(() =>
-      runSandboxed('Bad', 'steps([123, "Login"]);'),
-    ).toThrow('must contain only strings');
+    expect(() => runSandboxed('Bad', 'steps([123, "Login"]);')).toThrow(
+      'must contain only strings',
+    );
   });
 
   it('throws when steps() receives an array with an empty string', () => {
-    expect(() =>
-      runSandboxed('Bad', 'steps(["Login", "", "View"]);'),
-    ).toThrow('must not contain empty strings');
+    expect(() => runSandboxed('Bad', 'steps(["Login", "", "View"]);')).toThrow(
+      'must not contain empty strings',
+    );
   });
 
   it('throws when steps() is not called', () => {
-    expect(() =>
-      runSandboxed('Bad', '// just a comment'),
-    ).toThrow('No valid steps() call');
+    expect(() => runSandboxed('Bad', '// just a comment')).toThrow('No valid steps() call');
   });
 
   it('throws when steps() is called with an empty array', () => {
-    expect(() =>
-      runSandboxed('Bad', 'steps([]);'),
-    ).toThrow('No valid steps() call');
+    expect(() => runSandboxed('Bad', 'steps([]);')).toThrow('No valid steps() call');
   });
 
   it('throws on a syntax error in the script', () => {
-    expect(() =>
-      runSandboxed('Bad', 'steps([broken;;;'),
-    ).toThrow('Failed to evaluate');
+    expect(() => runSandboxed('Bad', 'steps([broken;;;')).toThrow('Failed to evaluate');
   });
 });
 
@@ -176,13 +170,11 @@ describe('extractFlowDef', () => {
   });
 
   it('handles multi-line pre-request scripts', () => {
-    const req = makeFlowRequest('Multi-line', [], [
-      '// Run: newman-flows run "Multi-line"',
-      'steps([',
-      '  "Step One",',
-      '  "Step Two"',
-      ']);',
-    ]);
+    const req = makeFlowRequest(
+      'Multi-line',
+      [],
+      ['// Run: newman-flows run "Multi-line"', 'steps([', '  "Step One",', '  "Step Two"', ']);'],
+    );
     expect(extractFlowDef(req).steps).toEqual(['Step One', 'Step Two']);
   });
 
@@ -253,8 +245,14 @@ describe('findFlowRequest', () => {
 describe('buildTempCollection', () => {
   it('assembles steps in the declared order', async () => {
     const { buildTempCollection } = await import('../../src/commands/run.js');
-    const stepA: PostmanItem = { name: 'Step A', request: { method: 'GET', url: { raw: 'http://x/a' } } };
-    const stepB: PostmanItem = { name: 'Step B', request: { method: 'POST', url: { raw: 'http://x/b' } } };
+    const stepA: PostmanItem = {
+      name: 'Step A',
+      request: { method: 'GET', url: { raw: 'http://x/a' } },
+    };
+    const stepB: PostmanItem = {
+      name: 'Step B',
+      request: { method: 'POST', url: { raw: 'http://x/b' } },
+    };
     const collection = makeCollection([], [{ name: 'Requests', item: [stepA, stepB] }]);
     const temp = buildTempCollection(collection, { name: 'My Flow', steps: ['Step A', 'Step B'] });
     expect((temp.item as PostmanItem[])[0].name).toBe('Step A');
@@ -266,11 +264,17 @@ describe('buildTempCollection', () => {
     const collection: PostmanCollection = {
       info: { name: 'Test', schema: 'x' },
       item: [
-        { name: 'Requests', item: [{ name: 'Step A', request: { method: 'GET', url: { raw: 'http://x/a' } } }] },
+        {
+          name: 'Requests',
+          item: [{ name: 'Step A', request: { method: 'GET', url: { raw: 'http://x/a' } } }],
+        },
         { name: 'Flows', item: [] },
       ],
       event: [
-        { listen: 'prerequest', script: { type: 'text/javascript', exec: ['var x = _flow_steps;'] } },
+        {
+          listen: 'prerequest',
+          script: { type: 'text/javascript', exec: ['var x = _flow_steps;'] },
+        },
         { listen: 'test', script: { type: 'text/javascript', exec: ['pm.test("ok", () => {});'] } },
       ],
     };
@@ -285,7 +289,10 @@ describe('buildTempCollection', () => {
     const collection: PostmanCollection = {
       info: { name: 'Test', schema: 'x' },
       item: [
-        { name: 'Requests', item: [{ name: 'Step A', request: { method: 'GET', url: { raw: 'http://x/a' } } }] },
+        {
+          name: 'Requests',
+          item: [{ name: 'Step A', request: { method: 'GET', url: { raw: 'http://x/a' } } }],
+        },
         { name: 'Flows', item: [] },
       ],
       event: [
@@ -293,7 +300,9 @@ describe('buildTempCollection', () => {
           listen: 'test',
           script: {
             type: 'text/javascript',
-            exec: ['pm.test("check _flow_steps is not set", () => { pm.expect(pm.globals.get("_flow_steps")).to.be.undefined; });'],
+            exec: [
+              'pm.test("check _flow_steps is not set", () => { pm.expect(pm.globals.get("_flow_steps")).to.be.undefined; });',
+            ],
           },
         },
       ],

--- a/test/unit/list.test.ts
+++ b/test/unit/list.test.ts
@@ -25,9 +25,9 @@ function makeCollection(overrides: Partial<PostmanCollection> = {}): PostmanColl
       {
         name: 'Requests',
         item: [
-          { name: 'Login',       request: { method: 'POST', url: { raw: 'http://x/login' } } },
-          { name: 'Create Org',  request: { method: 'POST', url: { raw: 'http://x/orgs' } } },
-          { name: 'View Org',    request: { method: 'GET',  url: { raw: 'http://x/orgs/1' } } },
+          { name: 'Login', request: { method: 'POST', url: { raw: 'http://x/login' } } },
+          { name: 'Create Org', request: { method: 'POST', url: { raw: 'http://x/orgs' } } },
+          { name: 'View Org', request: { method: 'GET', url: { raw: 'http://x/orgs/1' } } },
           { name: 'Upload File', request: { method: 'POST', url: { raw: 'http://x/upload' } } },
         ],
       },
@@ -37,26 +37,35 @@ function makeCollection(overrides: Partial<PostmanCollection> = {}): PostmanColl
           {
             name: 'Onboarding',
             request: { method: 'FLOW', url: { raw: 'about:blank' } },
-            event: [{
-              listen: 'prerequest',
-              script: { type: 'text/javascript', exec: ["steps(['Login', 'Create Org', 'View Org']);"] },
-            }],
+            event: [
+              {
+                listen: 'prerequest',
+                script: {
+                  type: 'text/javascript',
+                  exec: ["steps(['Login', 'Create Org', 'View Org']);"],
+                },
+              },
+            ],
           },
           {
             name: 'Upload',
             request: { method: 'FLOW', url: { raw: 'about:blank' } },
-            event: [{
-              listen: 'prerequest',
-              script: { type: 'text/javascript', exec: ["steps(['Login', 'Upload File']);"] },
-            }],
+            event: [
+              {
+                listen: 'prerequest',
+                script: { type: 'text/javascript', exec: ["steps(['Login', 'Upload File']);"] },
+              },
+            ],
           },
           {
             name: 'Single step flow',
             request: { method: 'FLOW', url: { raw: 'about:blank' } },
-            event: [{
-              listen: 'prerequest',
-              script: { type: 'text/javascript', exec: ["steps(['Login']);"] },
-            }],
+            event: [
+              {
+                listen: 'prerequest',
+                script: { type: 'text/javascript', exec: ["steps(['Login']);"] },
+              },
+            ],
           },
         ],
       },
@@ -164,7 +173,11 @@ describe('printFlowList', () => {
     printFlowList(makeCollection());
     // "Single step flow" is the longest name (16 chars); "Onboarding" (10) and
     // "Upload" (6) should be padded to the same width so columns align.
-    const lines = logSpy.mock.calls.flat().join('\n').split('\n').filter((l) => l.includes('•'));
+    const lines = logSpy.mock.calls
+      .flat()
+      .join('\n')
+      .split('\n')
+      .filter((l) => l.includes('•'));
     const colPositions = lines.map((l) => l.indexOf('('));
     expect(new Set(colPositions).size).toBe(1); // all '(' at the same column
     vi.restoreAllMocks();

--- a/test/unit/validate.test.ts
+++ b/test/unit/validate.test.ts
@@ -129,18 +129,14 @@ describe('validateCollection — flows', () => {
 
   it('errors when steps() receives non-string values', () => {
     const col = makeCollection();
-    (col.item[1].item![0].event![0].script as { exec: string[] }).exec = [
-      'steps([123, "Login"]);',
-    ];
+    (col.item[1].item![0].event![0].script as { exec: string[] }).exec = ['steps([123, "Login"]);'];
     const result = validateCollection(col);
     expect(result.errors.some((e) => e.includes('must contain only strings'))).toBe(true);
   });
 
   it('errors when steps() receives an empty string', () => {
     const col = makeCollection();
-    (col.item[1].item![0].event![0].script as { exec: string[] }).exec = [
-      'steps(["Login", ""]);',
-    ];
+    (col.item[1].item![0].event![0].script as { exec: string[] }).exec = ['steps(["Login", ""]);'];
     const result = validateCollection(col);
     expect(result.errors.some((e) => e.includes('must not contain empty strings'))).toBe(true);
   });
@@ -167,7 +163,9 @@ describe('validateCollection — flows', () => {
         { name: 'Flows', item: [] },
       ],
     });
-    expect(validateCollection(col).warnings.some((w) => w.includes('Duplicate request name "Login"'))).toBe(true);
+    expect(
+      validateCollection(col).warnings.some((w) => w.includes('Duplicate request name "Login"')),
+    ).toBe(true);
   });
 });
 
@@ -231,7 +229,7 @@ describe('validateCollection — absolute file paths', () => {
 describe('printValidationResult', () => {
   it('prints step counts from validFlows without touching the vm', () => {
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-    printValidationResult({ errors: [], warnings: [], validFlows: { 'My Flow': 4, 'Other': 2 } });
+    printValidationResult({ errors: [], warnings: [], validFlows: { 'My Flow': 4, Other: 2 } });
     const output = logSpy.mock.calls.flat().join('\n');
     expect(output).toContain('My Flow" — 4 steps');
     expect(output).toContain('Other" — 2 steps');


### PR DESCRIPTION
## Summary

- Adds `.github/hooks/pre-push` — runs Prettier (warn+prompt), ESLint (warn+prompt), typecheck, and unit tests before every push
- Adds `.github/scripts/setup_hooks.sh` — copies hooks from `.github/hooks/` into `.git/hooks/` on `npm install` (via the existing `postinstall` script)
- Reformats source and test files to satisfy Prettier (changes the hook will enforce going forward)

## Test plan

- [ ] `npm install` in a fresh clone installs the hook automatically
- [ ] `git push` runs all four checks and blocks on failure
- [ ] Prettier/ESLint failures prompt the user with a fix command rather than hard-aborting